### PR TITLE
fix(Document): Compare null or empty content

### DIFF
--- a/lib/Textmaster/Translator/Adapter/AbstractAdapter.php
+++ b/lib/Textmaster/Translator/Adapter/AbstractAdapter.php
@@ -145,6 +145,11 @@ abstract class AbstractAdapter implements AdapterInterface
         $diffs = [];
         $renderer = new \Diff_Renderer_Html_SideBySide();
         foreach ($values as $property => $value) {
+            if (null === $value || empty($value)) {
+                unset($values[$property]);
+                continue;
+            }
+
             $a = [$value];
             $b = [$content[$property]];
             if ($original) {


### PR DESCRIPTION
As TextMaster process a comparison with properties that may be `null` or empty, let's unset those properties if so.
