### PR TITLE
Add project documents statuses getter.

### DIFF
--- a/lib/Textmaster/Model/Project.php
+++ b/lib/Textmaster/Model/Project.php
@@ -384,4 +384,12 @@ class Project extends AbstractObject implements ProjectInterface
     {
         return 'textmaster.project';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDocumentsStatuses()
+    {
+        return $this->getProperty('documents_statuses');
+    }
 }

--- a/lib/Textmaster/Model/ProjectInterface.php
+++ b/lib/Textmaster/Model/ProjectInterface.php
@@ -288,4 +288,12 @@ interface ProjectInterface extends AbstractObjectInterface
      * @return ProjectInterface
      */
     public function launch();
+
+    /**
+     * Get project documents statuses summary.
+     * @see https://eu.app.textmaster.com/api-documentation#projects-get-a-project
+     *
+     * @return int[]
+     */
+    public function getDocumentsStatuses();
 }

--- a/test/Textmaster/Unit/Model/ProjectTest.php
+++ b/test/Textmaster/Unit/Model/ProjectTest.php
@@ -36,6 +36,19 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
             'project_briefing' => 'Lorem ipsum...',
             'options' => ['language_level' => 'premium'],
             'textmasters' => ['55c3763e656462000b000027'],
+            'documents_statuses' => [
+                'in_creation'        => 0,
+                'waiting_assignment' => 2,
+                'in_progress'        => 0,
+                'in_review'          => 0,
+                'incomplete'         => 0,
+                'completed'          => 0,
+                'paused'             => 0,
+                'canceled'           => 0,
+                'quality_control'    => 0,
+                'copyscape'          => 0,
+                'counting_words'     => 1,
+            ],
         ];
         $updateValues = [
             'id' => '123456',
@@ -167,6 +180,19 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
         $briefing = 'Lorem ipsum...';
         $options = ['language_level' => 'premium'];
         $textmasters = ['55c3763e656462000b000027'];
+        $documentsStatuses = [
+            'in_creation'        => 0,
+            'waiting_assignment' => 2,
+            'in_progress'        => 0,
+            'in_review'          => 0,
+            'incomplete'         => 0,
+            'completed'          => 0,
+            'paused'             => 0,
+            'canceled'           => 0,
+            'quality_control'    => 0,
+            'copyscape'          => 0,
+            'counting_words'     => 1,
+        ];
 
         $values = [
             'id' => $id,
@@ -179,6 +205,7 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
             'project_briefing' => $briefing,
             'options' => $options,
             'textmasters' => $textmasters,
+            'documents_statuses' => $documentsStatuses,
         ];
 
         $project = new Project($this->clientMock, $values);
@@ -193,6 +220,8 @@ class ProjectTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($briefing, $project->getBriefing());
         $this->assertSame($options, $project->getOptions());
         $this->assertSame($textmasters, $project->getTextmasters());
+        $this->assertEquals(2, $project->getDocumentsStatuses()[DocumentInterface::STATUS_WAITING_ASSIGNMENT]);
+        $this->assertEquals(1, $project->getDocumentsStatuses()[DocumentInterface::STATUS_COUNTING_WORDS]);
     }
 
     /**


### PR DESCRIPTION
The documents statuses can be useful to have a summary of the project without needing to fetch each document.